### PR TITLE
Update signing configuration for PGP subkey

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -31,6 +31,7 @@ project {
             param("env.JAVA_HOME", "%linux.java21.openjdk.64bit%")
             param("env.ORG_GRADLE_PROJECT_sonatypeUsername", "%mavenCentralStagingRepoUser%")
             password("env.ORG_GRADLE_PROJECT_sonatypePassword", "%mavenCentralStagingRepoPassword%")
+            param("env.PGP_SIGNING_KEY_ID", "%pgpSigningKeyId%")
             password("env.PGP_SIGNING_KEY", "%pgpSigningKey%")
             password("env.PGP_SIGNING_KEY_PASSPHRASE", "%pgpSigningPassphrase%")
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,7 +57,12 @@ publishing {
 
 signing {
     sign(publishing.publications["mavenJava"])
-    useInMemoryPgpKeys(System.getenv("PGP_SIGNING_KEY"), System.getenv("PGP_SIGNING_KEY_PASSPHRASE"))
+    useInMemoryPgpKeys(
+        // Key ID required when signing with a subkey
+        System.getenv("PGP_SIGNING_KEY_ID"),
+        System.getenv("PGP_SIGNING_KEY"),
+        System.getenv("PGP_SIGNING_KEY_PASSPHRASE")
+    )
 }
 
 tasks.jar {


### PR DESCRIPTION
After the move to a signing subkey, `useInMemoryPgpKeys` needs the key ID as its first argument. Without it the signing plugin falls back to the primary key and signing fails.

Two changes:

- the build file now calls the three-argument `useInMemoryPgpKeys(keyId, key, passphrase)`
- the publishing build configuration passes the ID as `env.PGP_SIGNING_KEY_ID`

The `pgpSigningKeyId` TeamCity parameter is already defined on the `OpenSourceProjects` project, so no new secret is needed.

This is the same change as the already-merged gradle/gradle-profiler#840. Part of gradle/gradle-private#5321, which was handed to DV DevProd because the original author has no push access to this repository.

**How this was verified:** `./gradlew help` configures the build cleanly, which compiles the changed build script and executes the three-argument call. The TeamCity side was checked against the live server: `pgpSigningKeyId` is defined on `OpenSourceProjects`, and no project in between overrides the `pgpSigning*` parameters, so `%pgpSigningKeyId%` resolves for this build configuration.

Docs: https://docs.gradle.org/current/userguide/signing_plugin.html#sec:subkeys
